### PR TITLE
fix(script): fix promise callback counting (catch) and error propagation

### DIFF
--- a/lib/internal-client.js
+++ b/lib/internal-client.js
@@ -85,7 +85,9 @@ exports.build = function(server, session, stack) {
         if (typeof fn === 'function') {
           // call our callback
           deferred.promise
-          .done(function () {
+          .then(function () {
+            fn(data, error);
+          }, function () {
             fn(data, error);
           });
         }

--- a/lib/script.js
+++ b/lib/script.js
@@ -162,39 +162,56 @@ function wrapPromise(promiseable, sandbox, events, done, sandboxRoot) {
   }
 
   var realThen = realPromise._then;
-
-  realPromise._then = function(onFulfilled, onRejected) {
+  var addCallback = function () {
     events.emit('addCallback');
-    var args = [];
-
-    // wrappedOnFulfilled
-    args[0] = function (res) {
-      var result = onFulfilled.apply(this, arguments);
-      events.emit('finishCallback');
-      
-      return isPromise(result)? wrapPromise(result, sandbox, events, done, sandboxRoot) : result;
-    };
+  };
+  var finishCallback = function() {
+    events.emit('finishCallback');
+  };
+  
+  addCallback();
+  realPromise.then(finishCallback, finishCallback);
+    
+  realPromise._then = function (onFulfilled, onRejected) {
+    var args = [undefined, undefined];
+    
+    if (onFulfilled) {
+      // wrappedOnFulfilled
+      args[0] = function (res) {
+        addCallback();
+        try {
+          var result = onFulfilled.apply(this, arguments);
+          return isPromise(result)? wrapPromise(result, sandbox, events, done, sandboxRoot) : result;
+        } catch (err) {
+          sandboxRoot._error = err;
+          throw err;
+        } finally {
+          finishCallback();
+        }
+      };
+    }
 
     if(onRejected) {
       args[1] =
         // wrappedOnRejected
-        function (err) {
-          var result = onRejected.apply(this, arguments);
-        
-          events.emit('finishCallback');
-          return isPromise(result)? wrapPromise(result, sandbox, events, done, sandboxRoot) : result;
-        };
-    } else {
-      args[1] =
-        function (err) {
-          events.emit('finishCallback');
-        
-          // this is needed to pass the error along
-          // couldn't find official docs to prove this is the way to go, 
-          // but at least ayepromise and when.js require it that way to chain rejections (without relying on rejected promise)
-          throw (err instanceof Error) ? err : new Error(err);
+        function (error) {
+          if (error === sandboxRoot._error) {
+            // if we're handling a previously uncaught error, remove it
+            sandboxRoot._error = null;
+          }
+          addCallback();
+          try {
+            var result = onRejected.apply(this, arguments);
+            return isPromise(result)? wrapPromise(result, sandbox, events, done, sandboxRoot) : result;
+          } catch (err) {
+            sandboxRoot._error = wrapError(err);
+            throw err;
+          } finally {
+            finishCallback();
+          }
         };
     }
+      
     for(var i = args.length; i< arguments.length; i++) {
       args[i] = arguments[i];
     }
@@ -220,8 +237,6 @@ function wrapAsyncFunction(asyncFunction, sandbox, events, done, sandboxRoot) {
         break;
       }
     }
-
-
     
     if (typeof callback === 'function') {
       events.emit('addCallback');

--- a/test-app/public/test/collection.test.js
+++ b/test-app/public/test/collection.test.js
@@ -968,14 +968,46 @@ describe('Collection', function() {
         return dpd.internalclientdetail.post({ masterId: masterId, data: "data 2" });
       }).then(function (data) {
         children.push(data);
-        return dpd.internalclientmaster.get(masterId).then(function (master) {
-          expect(master.children).to.eql(children);
-          expect(master.childrenPromise).to.eql(children);
-          expect(master.seenFinally).to.be.true;
-          done();
-        });
+        return dpd.internalclientmaster.get({ id: masterId, callback: true });
+      }).then(function (master) {
+        expect(master.children).to.eql(children);
+        return dpd.internalclientmaster.get({ id: masterId, promise: true });
+      }).then(function (master) {
+        expect(master.childrenPromise).to.eql(children);
+        expect(master.seenFinally).to.be.true;
+        expect(master.seenError).to.equal('test');
+        expect(master.shouldNotBeSet).to.not.exist;
+        expect(master.shouldNotBeSet2).to.not.exist;
+        done();
       }).fail(function (err) {
         done(err);
+      });
+    });
+      
+    it("should properly report uncaught error in callback and promise", function (done) {
+      var masterId;
+      var children = [];
+      dpd.internalclientmaster.post({ title: "hello" }).then(function (data) {
+        masterId = data.id;
+        return dpd.internalclientdetail.post({ masterId: masterId, data: "data 1" });
+      }).then(function (data) {
+        children.push(data);
+        return dpd.internalclientdetail.post({ masterId: masterId, data: "data 2" });
+      }).then(function (data) {
+        children.push(data);
+        return dpd.internalclientmaster.get({ id: masterId, promise: true, testUncaughtError: true });
+      }).then(function () {
+        throw "an error should've been returned";
+      }, function (err) {
+        expect(err).to.exist;
+        expect(err.message).to.equal('fail');
+        return dpd.internalclientmaster.get({ id: masterId, promise: true, testUncaughtError: true });
+      }).then(function() {
+        throw "an error should've been returned"; 
+      }, function (err) {
+        expect(err).to.exist;
+        expect(err.message).to.equal('fail');
+        done();
       });
     });
   });

--- a/test-app/public/test/collection.test.js
+++ b/test-app/public/test/collection.test.js
@@ -957,10 +957,10 @@ describe('Collection', function() {
     before(function(done) {
       cleanCollection(dpd.internalclientmaster, done);
     });
-    it("should work properly with normal callbacks and promises", function (done) {
+    
+    function populate(children) {
       var masterId;
-      var children = [];
-      dpd.internalclientmaster.post({ title: "hello" }).then(function (data) {
+      return dpd.internalclientmaster.post({ title: "hello" }).then(function (data) {
         masterId = data.id;
         return dpd.internalclientdetail.post({ masterId: masterId, data: "data 1" });
       }).then(function (data) {
@@ -968,11 +968,44 @@ describe('Collection', function() {
         return dpd.internalclientdetail.post({ masterId: masterId, data: "data 2" });
       }).then(function (data) {
         children.push(data);
+        return masterId;
+      });
+    }
+    
+    it("should work properly with callbacks", function (done) {
+      var children = [];
+      populate(children).then(function (masterId) {
         return dpd.internalclientmaster.get({ id: masterId, callback: true });
       }).then(function (master) {
         expect(master.children).to.eql(children);
+        done();
+      }).fail(function (err) {
+        done(err);
+      });
+    });
+      
+    it("should work properly with promises", function (done) {
+      var children = [];
+      populate(children).then(function (masterId) {
         return dpd.internalclientmaster.get({ id: masterId, promise: true });
       }).then(function (master) {
+        expect(master.childrenPromise).to.eql(children);
+        expect(master.seenFinally).to.be.true;
+        expect(master.seenError).to.equal('test');
+        expect(master.shouldNotBeSet).to.not.exist;
+        expect(master.shouldNotBeSet2).to.not.exist;
+        done();
+      }).fail(function (err) {
+        done(err);
+      });
+    });
+
+    it("should work properly with both normal callbacks and promises at the same time", function (done) {
+      var children = [];
+      populate(children).then(function (masterId) {
+        return dpd.internalclientmaster.get({ id: masterId, callback: true, promise: true });
+      }).then(function (master) {
+        expect(master.children).to.eql(children);
         expect(master.childrenPromise).to.eql(children);
         expect(master.seenFinally).to.be.true;
         expect(master.seenError).to.equal('test');
@@ -987,21 +1020,15 @@ describe('Collection', function() {
     it("should properly report uncaught error in callback and promise", function (done) {
       var masterId;
       var children = [];
-      dpd.internalclientmaster.post({ title: "hello" }).then(function (data) {
-        masterId = data.id;
-        return dpd.internalclientdetail.post({ masterId: masterId, data: "data 1" });
-      }).then(function (data) {
-        children.push(data);
-        return dpd.internalclientdetail.post({ masterId: masterId, data: "data 2" });
-      }).then(function (data) {
-        children.push(data);
+      populate(children).then(function (mid){
+        masterId = mid;
         return dpd.internalclientmaster.get({ id: masterId, promise: true, testUncaughtError: true });
       }).then(function () {
         throw "an error should've been returned";
       }, function (err) {
         expect(err).to.exist;
         expect(err.message).to.equal('fail');
-        return dpd.internalclientmaster.get({ id: masterId, promise: true, testUncaughtError: true });
+        return dpd.internalclientmaster.get({ id: masterId, callback: true, testUncaughtError: true });
       }).then(function() {
         throw "an error should've been returned"; 
       }, function (err) {

--- a/test-app/resources/internal-client-master/get.js
+++ b/test-app/resources/internal-client-master/get.js
@@ -1,10 +1,33 @@
-dpd.internalclientdetail.get({masterId: this.id}).then(function (data) {
-    this.childrenPromise = data;
-}).finally(function (data) {
-    this.seenFinally = true;
-});
-
-
-dpd.internalclientdetail.get({masterId: this.id}, function(data, err) {
-    this.children = data;
-});
+if (ctx.query.testUncaughtError) {
+  if (ctx.query.promise) {
+    dpd.internalclientdetail.get({ masterId: this.id }).then(function (data) {
+      throw "fail";
+    });
+  } else if (ctx.query.callback) {
+    dpd.internalclientdetail.get({ masterId: this.id }, function (data, err) {
+      throw "fail";
+    });
+  }
+} else {
+  if (ctx.query.promise) {
+    dpd.internalclientdetail.get({ masterId: this.id }).then(function (data) {
+      this.childrenPromise = data;
+    }).catch(function () {
+      this.shouldNotBeSet = true;
+    }).catch(function () {
+      this.shouldNotBeSet2 = true;
+    }).then(function () {
+      throw "test";
+    }).catch(function (err) {
+      this.seenError = err;
+    }).finally(function (data) {
+      this.seenFinally = true;
+    });
+  }
+  
+  if (ctx.query.callback) {
+    dpd.internalclientdetail.get({ masterId: this.id }, function (data, err) {
+      this.children = data;
+    });
+  }
+}


### PR DESCRIPTION
Refactoring to fix issue when chaining `catch` when there wasn't any error not decrementing the callback counter properly.

Fix issue with error propagation when an error is unhandled in a promise.
Improve promise integration tests.
